### PR TITLE
Added methods for mutual inductance of two arbitrary paths

### DIFF
--- a/src/inductance/filaments.py
+++ b/src/inductance/filaments.py
@@ -199,7 +199,7 @@ def _loop_segmented_mutual(r, z, pts):
         delta = pts[i, :] - pts[i + 1, :]
         rs = math.sqrt(midp[0] ** 2 + midp[1] ** 2)
         zs = midp[2]
-        rdphi = (delta[0] * midp[1] - delta[1] * midp[0]) / rs
+        rdphi = (delta[0] * midp[1] - delta[1] * midp[0]) / rs**2
         M += AGreen(r, z, rs, zs) * rdphi
 
     return M
@@ -214,10 +214,10 @@ def mutual_filaments_segmented(fils, pts):
     return M
 
 
-def M_filsol_path(fil, pts, nt, ds=0):
+def M_filsol_path(fils, pts, nt, ds=0):
     """Mutual inductance between a set of axisymmetric filaments and a path from pts."""
     segs, _ = segment_path(pts, ds)
-    return nt * mutual_filaments_segmented(fil, segs)
+    return nt * mutual_filaments_segmented(fils, segs)
 
 
 @njit(parallel=True)

--- a/src/inductance/filaments.py
+++ b/src/inductance/filaments.py
@@ -190,8 +190,8 @@ def segment_path(pts, ds=0, close=False):
 
 @njit
 def _loop_segmented_mutual(r, z, pts):
-    # segments is array of n x 3 (x,y,z)
-    # segments should contain first point at start AND end.
+    # pts is array of n x 3 (x,y,z)
+    # pts should contain first point at start AND end.
     # r, z is r & z of loop
     M = float(0)
     for i in range(pts.shape[0] - 1):

--- a/src/inductance/filaments.py
+++ b/src/inductance/filaments.py
@@ -93,6 +93,36 @@ def AGreen(r, z, a, b):
 
 
 @njit
+def ASegment(pts, xyz, uvw):
+    """Psi at positions pts, due to a linear current segment uvw located at xyz.
+    Derived from https://doi.org/10.1016/j.cpc.2023.108692, Eq. 20
+
+    Args:
+        pts (array): coordinates to calculate vector potential at, N x (x,y,z)
+        xyz (array): coordinates of base of current element (x,y,z)
+        uvw (array): displacement vector for length of element
+
+    Returns:
+        array: Psi at pts in Weber / Amp, N x (Psix,Psiy,Psiz)
+    """
+    mu02pi = 2e-7 #mu_0/2pi in H/m
+    L = math.sqrt(uvw[0]**2+uvw[1]**2+uvw[2]**2)
+    _uvw = uvw/L
+    diffs = pts[:]-xyz
+    zs = uvw[0]*diffs[:,0] + uvw[1]*diffs[:,1] + uvw[2]*diffs[:,2]
+    zvecs = zs[:,None]*_uvw
+    rhovecs = diffs-zvecs
+    rhos = np.sqrt(rhovecs[:,0]**2+rhovecs[:,1]**2+rhovecs[:,2]**2)/L
+    zs /= L
+
+    ris = np.sqrt(rhos**2+zs**2)
+    rfs = np.sqrt(rhos**2+(1-zs)**2)
+    epsilons = 1/(ris+rfs)
+
+    return mu02pi*np.arctanh(epsilons)[:,None]*_uvw
+
+
+@njit
 def BrGreen(r, z, a, b):
     """Br at position r, z, due to a filament with radius a, and z postion b.
 
@@ -219,6 +249,17 @@ def M_filsol_path(fils, pts, nt, ds=0):
     segs, _ = segment_path(pts, ds)
     return nt * mutual_filaments_segmented(fils, segs)
 
+@njit
+def mutual_segmented_segmented(pts1, pts2):
+    Avecs = np.zeros_like(pts2)
+    for i in range(pts1.shape[0] - 1):
+        xyz = pts1[i]
+        uvw = pts1[i+1]-pts1[i]
+        Avecs += ASegment(pts2,xyz,uvw)
+    A_midps = (Avecs[1:]+Avecs[:-1])/2
+    deltas = pts2[1:]-pts2[:-1]
+    dots = deltas[:,0]*A_midps[:,0] + deltas[:,1]*A_midps[:,1] + deltas[:,2]*A_midps[:,2]
+    return np.sum(dots)
 
 @njit(parallel=True)
 def segmented_self_inductance(pts, s, a):

--- a/src/inductance/filaments.py
+++ b/src/inductance/filaments.py
@@ -105,21 +105,21 @@ def ASegment(pts, xyz, uvw):
     Returns:
         array: Psi at pts in Weber / Amp, N x (Psix,Psiy,Psiz)
     """
-    mu02pi = 2e-7 #mu_0/2pi in H/m
-    L = math.sqrt(uvw[0]**2+uvw[1]**2+uvw[2]**2)
-    _uvw = uvw/L
-    diffs = pts[:]-xyz
-    zs = uvw[0]*diffs[:,0] + uvw[1]*diffs[:,1] + uvw[2]*diffs[:,2]
-    zvecs = zs[:,None]*_uvw
-    rhovecs = diffs-zvecs
-    rhos = np.sqrt(rhovecs[:,0]**2+rhovecs[:,1]**2+rhovecs[:,2]**2)/L
+    mu02pi = 2e-7  # mu_0/2pi in H/m
+    L = math.sqrt(uvw[0] ** 2 + uvw[1] ** 2 + uvw[2] ** 2)
+    _uvw = uvw / L
+    diffs = pts[:] - xyz
+    zs = uvw[0] * diffs[:, 0] + uvw[1] * diffs[:, 1] + uvw[2] * diffs[:, 2]
+    zvecs = zs[:, None] * _uvw
+    rhovecs = diffs - zvecs
+    rhos = np.sqrt(rhovecs[:, 0] ** 2 + rhovecs[:, 1] ** 2 + rhovecs[:, 2] ** 2) / L
     zs /= L
 
-    ris = np.sqrt(rhos**2+zs**2)
-    rfs = np.sqrt(rhos**2+(1-zs)**2)
-    epsilons = 1/(ris+rfs)
+    ris = np.sqrt(rhos**2 + zs**2)
+    rfs = np.sqrt(rhos**2 + (1 - zs) ** 2)
+    epsilons = 1 / (ris + rfs)
 
-    return mu02pi*np.arctanh(epsilons)[:,None]*_uvw
+    return mu02pi * np.arctanh(epsilons)[:, None] * _uvw
 
 
 @njit
@@ -240,12 +240,17 @@ def _segmented_segmented_mutual(pts1, pts2):
     Avecs = np.zeros_like(pts2)
     for i in range(pts1.shape[0] - 1):
         xyz = pts1[i]
-        uvw = pts1[i+1]-pts1[i]
-        Avecs += ASegment(pts2,xyz,uvw)
-    A_midps = (Avecs[1:]+Avecs[:-1])/2
-    deltas = pts2[1:]-pts2[:-1]
-    dots = deltas[:,0]*A_midps[:,0] + deltas[:,1]*A_midps[:,1] + deltas[:,2]*A_midps[:,2]
+        uvw = pts1[i + 1] - pts1[i]
+        Avecs += ASegment(pts2, xyz, uvw)
+    A_midps = (Avecs[1:] + Avecs[:-1]) / 2
+    deltas = pts2[1:] - pts2[:-1]
+    dots = (
+        deltas[:, 0] * A_midps[:, 0]
+        + deltas[:, 1] * A_midps[:, 1]
+        + deltas[:, 2] * A_midps[:, 2]
+    )
     return np.sum(dots)
+
 
 @njit(parallel=True)
 def mutual_filaments_segmented(fils, pts):
@@ -262,11 +267,11 @@ def M_filsol_path(fils, pts, nt, ds=0):
     return nt * mutual_filaments_segmented(fils, segs)
 
 
-def M_path_path(pts1,pts2, ds1=0, ds2=0):
+def M_path_path(pts1, pts2, ds1=0, ds2=0):
     """Mutual inductance between two pts paths"""
-    segs1, _ = segment_path(pts1,ds1)
-    segs2, _ = segment_path(pts2,ds2)
-    return _segmented_segmented_mutual(segs1,segs2)
+    segs1, _ = segment_path(pts1, ds1)
+    segs2, _ = segment_path(pts2, ds2)
+    return _segmented_segmented_mutual(segs1, segs2)
 
 
 @njit(parallel=True)

--- a/src/inductance/filaments.py
+++ b/src/inductance/filaments.py
@@ -95,6 +95,7 @@ def AGreen(r, z, a, b):
 @njit
 def ASegment(pts, xyz, uvw):
     """Psi at positions pts, due to a linear current segment uvw located at xyz.
+
     Derived from https://doi.org/10.1016/j.cpc.2023.108692, Eq. 20
 
     Args:
@@ -268,7 +269,7 @@ def M_filsol_path(fils, pts, nt, ds=0):
 
 
 def M_path_path(pts1, pts2, ds1=0, ds2=0):
-    """Mutual inductance between two pts paths"""
+    """Mutual inductance between two pts paths."""
     segs1, _ = segment_path(pts1, ds1)
     segs2, _ = segment_path(pts2, ds2)
     return _segmented_segmented_mutual(segs1, segs2)

--- a/tests/test_ldx.py
+++ b/tests/test_ldx.py
@@ -1,4 +1,4 @@
-"""Test filamentation and inducatance of LDX coils."""
+"""Test filamentation and inductance of LDX coils."""
 
 import unittest
 

--- a/tests/test_mutual_path.py
+++ b/tests/test_mutual_path.py
@@ -1,0 +1,56 @@
+"""Test the mutual inductance of filaments and paths"""
+
+import unittest
+
+import coverage_env  # noqa: F401
+
+from inductance.filaments import mutual_inductance_fil,_loop_segmented_mutual,mutual_segmented_segmented
+from numpy import array,dstack,linspace,ones_like,sin,cos,pi
+
+class TestMutual(unittest.TestCase):
+    """Test and compare mutual inductance of filaments and paths"""
+
+    def setUp(self) -> None:
+        self.coplanar_fil1 = array([1,10,1])
+        self.coplanar_fil2 = array([100,10,1])
+        t = linspace(0,2*pi,10000)
+        self.coplanar_fil1_path = dstack((-1*sin(t),1*cos(t),10*ones_like(t)))[0]
+        self.coplanar_fil2_path = dstack((-100*sin(t),100*cos(t),10*ones_like(t)))[0]
+
+        self.coaxial_fil1 = array([1,0,1])
+        self.coaxial_fil2 = array([1,100,1])
+        self.coaxial_fil1_path = dstack((-sin(t),cos(t),0*ones_like(t)))[0]
+        self.coaxial_fil2_path = dstack((-sin(t),cos(t),100*ones_like(t)))[0]
+
+        mu_0 = 1.256637062e-6 #H/m
+        self.coplanar_analytic_sol = mu_0*pi*self.coplanar_fil1[0]**2/(2*self.coplanar_fil2[0])
+        self.coaxial_analytic_sol = mu_0*pi*self.coaxial_fil1[0]**4/(2*abs(self.coaxial_fil2[1]-self.coaxial_fil1[1])**3)
+        return super().setUp()
+    
+    def test_mutual_fil_fil(self):
+        """Test filaments.mutual_inductance_fil"""
+        coplanar_filaments_sol = mutual_inductance_fil(self.coplanar_fil1,self.coplanar_fil2)
+        coaxial_filaments_sol = mutual_inductance_fil(self.coaxial_fil1,self.coaxial_fil2)
+
+        self.assertAlmostEqual(self.coplanar_analytic_sol,coplanar_filaments_sol,places=11)
+        self.assertAlmostEqual(self.coaxial_analytic_sol,coaxial_filaments_sol,places=11)
+
+    def test_mutual_fil_path(self):
+        """Test filaments._loop_segmented_mutual"""
+        coplanar_path_sol = _loop_segmented_mutual(*self.coplanar_fil1[:2],self.coplanar_fil2_path)
+        coaxial_path_sol = _loop_segmented_mutual(*self.coaxial_fil1[:2],self.coaxial_fil2_path)
+        
+        self.assertAlmostEqual(coplanar_path_sol,self.coplanar_analytic_sol,places=11)
+        self.assertAlmostEqual(coaxial_path_sol,self.coaxial_analytic_sol,places=11)
+
+    def test_mutual_path_path(self):
+        """Test filaments.mutual_segmented_segmented"""
+        coplanar_path_sol = mutual_segmented_segmented(self.coplanar_fil1_path,self.coplanar_fil2_path)
+        coaxial_path_sol = mutual_segmented_segmented(self.coaxial_fil1_path,self.coaxial_fil2_path)
+        
+        self.assertAlmostEqual(coplanar_path_sol,self.coplanar_analytic_sol,places=10)
+        self.assertAlmostEqual(coaxial_path_sol,self.coaxial_analytic_sol,places=10)
+        
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mutual_path.py
+++ b/tests/test_mutual_path.py
@@ -1,4 +1,4 @@
-"""Test the mutual inductance of filaments and paths"""
+"""Test the mutual inductance of filaments and paths."""
 
 import unittest
 
@@ -13,9 +13,10 @@ from inductance.filaments import (
 
 
 class TestMutual(unittest.TestCase):
-    """Test and compare mutual inductance of filaments and paths"""
+    """Test and compare mutual inductance of filaments and paths."""
 
     def setUp(self) -> None:
+        """Set up the test data."""
         self.coplanar_fil1 = array([1, 10, 1])
         self.coplanar_fil2 = array([100, 10, 1])
         t = linspace(0, 2 * pi, 10000)
@@ -44,7 +45,7 @@ class TestMutual(unittest.TestCase):
         return super().setUp()
 
     def test_mutual_fil_fil(self):
-        """Test filaments.mutual_inductance_fil"""
+        """Test filaments.mutual_inductance_fil."""
         coplanar_filaments_sol = mutual_inductance_fil(
             self.coplanar_fil1, self.coplanar_fil2
         )
@@ -60,7 +61,7 @@ class TestMutual(unittest.TestCase):
         )
 
     def test_mutual_fil_path(self):
-        """Test filaments._loop_segmented_mutual"""
+        """Test filaments._loop_segmented_mutual."""
         coplanar_path_sol = _loop_segmented_mutual(
             *self.coplanar_fil1[:2], self.coplanar_fil2_path
         )
@@ -72,7 +73,7 @@ class TestMutual(unittest.TestCase):
         self.assertAlmostEqual(coaxial_path_sol, self.coaxial_analytic_sol, places=11)
 
     def test_mutual_path_path(self):
-        """Test filaments.M_path_path"""
+        """Test filaments.M_path_path."""
         coplanar_path_sol = M_path_path(
             self.coplanar_fil1_path, self.coplanar_fil2_path
         )

--- a/tests/test_mutual_path.py
+++ b/tests/test_mutual_path.py
@@ -4,7 +4,7 @@ import unittest
 
 import coverage_env  # noqa: F401
 
-from inductance.filaments import mutual_inductance_fil,_loop_segmented_mutual,mutual_segmented_segmented
+from inductance.filaments import mutual_inductance_fil,_loop_segmented_mutual,M_path_path
 from numpy import array,dstack,linspace,ones_like,sin,cos,pi
 
 class TestMutual(unittest.TestCase):
@@ -44,9 +44,9 @@ class TestMutual(unittest.TestCase):
         self.assertAlmostEqual(coaxial_path_sol,self.coaxial_analytic_sol,places=11)
 
     def test_mutual_path_path(self):
-        """Test filaments.mutual_segmented_segmented"""
-        coplanar_path_sol = mutual_segmented_segmented(self.coplanar_fil1_path,self.coplanar_fil2_path)
-        coaxial_path_sol = mutual_segmented_segmented(self.coaxial_fil1_path,self.coaxial_fil2_path)
+        """Test filaments.M_path_path"""
+        coplanar_path_sol = M_path_path(self.coplanar_fil1_path,self.coplanar_fil2_path)
+        coaxial_path_sol = M_path_path(self.coaxial_fil1_path,self.coaxial_fil2_path)
         
         self.assertAlmostEqual(coplanar_path_sol,self.coplanar_analytic_sol,places=10)
         self.assertAlmostEqual(coaxial_path_sol,self.coaxial_analytic_sol,places=10)

--- a/tests/test_mutual_path.py
+++ b/tests/test_mutual_path.py
@@ -3,54 +3,84 @@
 import unittest
 
 import coverage_env  # noqa: F401
+from numpy import array, cos, dstack, linspace, ones_like, pi, sin
 
-from inductance.filaments import mutual_inductance_fil,_loop_segmented_mutual,M_path_path
-from numpy import array,dstack,linspace,ones_like,sin,cos,pi
+from inductance.filaments import (
+    M_path_path,
+    _loop_segmented_mutual,
+    mutual_inductance_fil,
+)
+
 
 class TestMutual(unittest.TestCase):
     """Test and compare mutual inductance of filaments and paths"""
 
     def setUp(self) -> None:
-        self.coplanar_fil1 = array([1,10,1])
-        self.coplanar_fil2 = array([100,10,1])
-        t = linspace(0,2*pi,10000)
-        self.coplanar_fil1_path = dstack((-1*sin(t),1*cos(t),10*ones_like(t)))[0]
-        self.coplanar_fil2_path = dstack((-100*sin(t),100*cos(t),10*ones_like(t)))[0]
+        self.coplanar_fil1 = array([1, 10, 1])
+        self.coplanar_fil2 = array([100, 10, 1])
+        t = linspace(0, 2 * pi, 10000)
+        self.coplanar_fil1_path = dstack((-1 * sin(t), 1 * cos(t), 10 * ones_like(t)))[
+            0
+        ]
+        self.coplanar_fil2_path = dstack(
+            (-100 * sin(t), 100 * cos(t), 10 * ones_like(t))
+        )[0]
 
-        self.coaxial_fil1 = array([1,0,1])
-        self.coaxial_fil2 = array([1,100,1])
-        self.coaxial_fil1_path = dstack((-sin(t),cos(t),0*ones_like(t)))[0]
-        self.coaxial_fil2_path = dstack((-sin(t),cos(t),100*ones_like(t)))[0]
+        self.coaxial_fil1 = array([1, 0, 1])
+        self.coaxial_fil2 = array([1, 100, 1])
+        self.coaxial_fil1_path = dstack((-sin(t), cos(t), 0 * ones_like(t)))[0]
+        self.coaxial_fil2_path = dstack((-sin(t), cos(t), 100 * ones_like(t)))[0]
 
-        mu_0 = 1.256637062e-6 #H/m
-        self.coplanar_analytic_sol = mu_0*pi*self.coplanar_fil1[0]**2/(2*self.coplanar_fil2[0])
-        self.coaxial_analytic_sol = mu_0*pi*self.coaxial_fil1[0]**4/(2*abs(self.coaxial_fil2[1]-self.coaxial_fil1[1])**3)
+        mu_0 = 1.256637062e-6  # H/m
+        self.coplanar_analytic_sol = (
+            mu_0 * pi * self.coplanar_fil1[0] ** 2 / (2 * self.coplanar_fil2[0])
+        )
+        self.coaxial_analytic_sol = (
+            mu_0
+            * pi
+            * self.coaxial_fil1[0] ** 4
+            / (2 * abs(self.coaxial_fil2[1] - self.coaxial_fil1[1]) ** 3)
+        )
         return super().setUp()
-    
+
     def test_mutual_fil_fil(self):
         """Test filaments.mutual_inductance_fil"""
-        coplanar_filaments_sol = mutual_inductance_fil(self.coplanar_fil1,self.coplanar_fil2)
-        coaxial_filaments_sol = mutual_inductance_fil(self.coaxial_fil1,self.coaxial_fil2)
+        coplanar_filaments_sol = mutual_inductance_fil(
+            self.coplanar_fil1, self.coplanar_fil2
+        )
+        coaxial_filaments_sol = mutual_inductance_fil(
+            self.coaxial_fil1, self.coaxial_fil2
+        )
 
-        self.assertAlmostEqual(self.coplanar_analytic_sol,coplanar_filaments_sol,places=11)
-        self.assertAlmostEqual(self.coaxial_analytic_sol,coaxial_filaments_sol,places=11)
+        self.assertAlmostEqual(
+            self.coplanar_analytic_sol, coplanar_filaments_sol, places=11
+        )
+        self.assertAlmostEqual(
+            self.coaxial_analytic_sol, coaxial_filaments_sol, places=11
+        )
 
     def test_mutual_fil_path(self):
         """Test filaments._loop_segmented_mutual"""
-        coplanar_path_sol = _loop_segmented_mutual(*self.coplanar_fil1[:2],self.coplanar_fil2_path)
-        coaxial_path_sol = _loop_segmented_mutual(*self.coaxial_fil1[:2],self.coaxial_fil2_path)
-        
-        self.assertAlmostEqual(coplanar_path_sol,self.coplanar_analytic_sol,places=11)
-        self.assertAlmostEqual(coaxial_path_sol,self.coaxial_analytic_sol,places=11)
+        coplanar_path_sol = _loop_segmented_mutual(
+            *self.coplanar_fil1[:2], self.coplanar_fil2_path
+        )
+        coaxial_path_sol = _loop_segmented_mutual(
+            *self.coaxial_fil1[:2], self.coaxial_fil2_path
+        )
+
+        self.assertAlmostEqual(coplanar_path_sol, self.coplanar_analytic_sol, places=11)
+        self.assertAlmostEqual(coaxial_path_sol, self.coaxial_analytic_sol, places=11)
 
     def test_mutual_path_path(self):
         """Test filaments.M_path_path"""
-        coplanar_path_sol = M_path_path(self.coplanar_fil1_path,self.coplanar_fil2_path)
-        coaxial_path_sol = M_path_path(self.coaxial_fil1_path,self.coaxial_fil2_path)
-        
-        self.assertAlmostEqual(coplanar_path_sol,self.coplanar_analytic_sol,places=10)
-        self.assertAlmostEqual(coaxial_path_sol,self.coaxial_analytic_sol,places=10)
-        
+        coplanar_path_sol = M_path_path(
+            self.coplanar_fil1_path, self.coplanar_fil2_path
+        )
+        coaxial_path_sol = M_path_path(self.coaxial_fil1_path, self.coaxial_fil2_path)
+
+        self.assertAlmostEqual(coplanar_path_sol, self.coplanar_analytic_sol, places=10)
+        self.assertAlmostEqual(coaxial_path_sol, self.coaxial_analytic_sol, places=10)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added filaments.M_path_path which will return the mutual inductance of two arbitrary closed paths defined by a list of points. Points list follows same convention as other existing functions (first and last point must be same). Also added test file to verify old methods for filament-filament, filament-path, and path-path mutual inductance functions against two situations with known analytic solutions.