### PR TITLE
Make releases work from GitHub instead of a local repo

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,4 +1,11 @@
-name: Bump version
+name: Prepare release
+
+# Bumps the version and opens a pull request with the change.
+#
+# Merging that PR pushes to main, which triggers the Release workflow: it
+# detects the changed version, tags it, publishes to PyPI and publishes the
+# drafted release notes.  Nothing here pushes to main directly, so this works
+# with branch protection and the release still gets a review + a test run.
 
 on:
   workflow_dispatch:
@@ -13,30 +20,60 @@ on:
           - minor
           - patch
 
+permissions: {}
+
 jobs:
-  build:
+  prepare:
+    name: Open release pull request
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: Checkout the code
+      - name: Check out the code
         uses: actions/checkout@v7
 
-      - name: Set Git configuration for GitHub Actions Bot
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
 
-      - name: Bump version
+      - name: Bump the version
         id: bump
-        uses: callowayproject/bump-my-version@1.5.1
         env:
-          BUMPVERSION_TAG: "true"
-        with:
-          args: ${{ inputs.bump-type }}
-          github-token: ${{ secrets.GH_TOKEN }}
-
-      - name: Check
-        if: steps.bump.outputs.bumped == 'true'
+          BUMP_TYPE: ${{ inputs.bump-type }}
         run: |
-          echo "Version was bumped from ${{ steps.bump.outputs.previous-version }} to ${{ steps.bump.outputs.current-version }}!"
+          previous="$(uv run --only-dev bump-my-version show current_version)"
+          echo "previous-version=$previous" >> "$GITHUB_OUTPUT"
+
+          # bump-my-version is configured with commit = false and tag = false,
+          # so this only rewrites the version strings.  The pull request below
+          # makes the commit; the Release workflow makes the tag.
+          uv run --only-dev bump-my-version bump "$BUMP_TYPE"
+
+          current="$(uv run --only-dev bump-my-version show current_version)"
+          echo "current-version=$current" >> "$GITHUB_OUTPUT"
+          echo "Bumped $previous -> $current"
+
+      - name: Open the release pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          # A PAT is needed for the PR to trigger the Tests workflow; pull
+          # requests opened with the default GITHUB_TOKEN do not start other
+          # workflow runs.
+          token: ${{ secrets.GH_TOKEN || github.token }}
+          branch: release/v${{ steps.bump.outputs.current-version }}
+          delete-branch: true
+          commit-message: "Bump version: ${{ steps.bump.outputs.previous-version }} → ${{ steps.bump.outputs.current-version }}"
+          title: "Release v${{ steps.bump.outputs.current-version }}"
+          labels: release
+          body: |
+            Version bump `${{ steps.bump.outputs.previous-version }}` → `${{ steps.bump.outputs.current-version }}`,
+            prepared by the *Prepare release* workflow.
+
+            Merging this pull request will:
+
+            - tag `v${{ steps.bump.outputs.current-version }}` on `main`
+            - publish the package to PyPI
+            - publish the drafted release notes
+
+            Close it if you are not ready to release; nothing is tagged or
+            published until it merges.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,10 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
+          # The dev bump above always lands on the same next patch version, so
+          # every merge that isn't a release builds a version TestPyPI may
+          # already have.  Don't fail the run over it.
+          skip-existing: true
 
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v7


### PR DESCRIPTION
The **Prepare release** workflow (was: Bump version) bumped the version but never landed it, which is why releases had to be cut by hand from a local clone.

## Why it failed

`[tool.bumpversion]` sets `commit = false`, so `bump-my-version bump <type>` only rewrites the version strings. Verified in a scratch clone:

```
$ bump-my-version bump patch
$ git status --short
 M pyproject.toml        # no commit, no tag
```

The action *does* push (`ad-m/github-push-action` is its last step), but there was no commit to push, so it pushed nothing and the edit died with the runner. `BUMPVERSION_TAG: "true"` did create a tag in the runner, but that step pushes a *branch* ref, not tags, so the tag went nowhere either.

Two smaller things were also confusing it: the action runs its own `actions/checkout` with `persist-credentials: false` and sets its own git identity, so the checkout and both `git config` steps in the job were being overwritten.

## What this does instead

**Actions → Prepare release → patch/minor/major** → bumps the version and opens a `Release vX.Y.Z` PR → Tests run on it → **merge when it looks right** → the existing Release workflow detects the changed version on `main`, tags it, publishes to PyPI and publishes the drafted notes.

Nothing is tagged or published until that PR merges; closing it aborts the release cleanly. Nothing pushes to `main`, so this works under branch protection.

`pyproject.toml` is unchanged, and `commit = false` / `tag = false` are now correct rather than accidental — responsibilities are split: `create-pull-request` makes the commit, and Release is the only thing that makes tags. Previously two workflows could both tag.

## Also: Release no longer fails on ordinary merges

The dev-release path runs `bump-my-version bump patch` in the runner and publishes to TestPyPI. With `serialize = ["{major}.{minor}.{patch}"]` that is always the same next patch version, so the first such merge uploaded it and every later one failed with "file already exists". Added `skip-existing: true` to the TestPyPI step only.

## Note

The PR is opened with `secrets.GH_TOKEN || github.token`. A PR opened by the default `GITHUB_TOKEN` will **not** trigger the Tests workflow, so if `GH_TOKEN` has expired the release PR would merge untested — worth confirming that secret is still valid.

`workflow_dispatch` only appears in the UI for workflows on the default branch, so the run button shows up once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)