### PR TITLE
Upgrade pip before installing the docs group

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,13 +5,16 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    # must satisfy requires-python in pyproject.toml (>=3.11,<3.15)
+    # must satisfy requires-python in pyproject.toml
     python: "3.13"
   jobs:
     pre_install:
       # docs dependencies live in the [dependency-groups] docs table of
       # pyproject.toml; docs/requirements.txt went away in the switch to uv.
-      # pip grew --group in 25.1, and RTD upgrades pip in the build venv.
+      # pip only grew --group in 25.1, and pre_install runs before Read the
+      # Docs upgrades pip, so the virtualenv's bundled pip is too old: upgrade
+      # it here first or the --group below fails with "no such option".
+      - python -m pip install --upgrade pip
       - python -m pip install --group docs
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
The docs build still fails after #207. My fault: I claimed RTD upgrades pip in the build venv before the install step. It does — but *after* `pre_install`, not before. From build [34075594](https://readthedocs.org/projects/inductance/builds/34075594/) of `latest`, on `7ca3472` (which has the corrected config):

```
exit=0 :: python -mvirtualenv $READTHEDOCS_VIRTUALENV_PATH
exit=2 :: python -m pip install --group docs
             no such option: --group
```

So the job ran against the pip that virtualenv seeds, which predates `--group` (pip 25.1). Fix is to upgrade pip in the same job.

## Verified

Replayed the full sequence in a clean 3.13 venv pinned back to **pip 24.0**, the condition that broke it:

```console
$ python -m pip --version                  # pip 24.0
$ python -m pip install --group docs       # no such option: --group   ← reproduces the failure
$ python -m pip install --upgrade pip      # 26.2.1
$ python -m pip install --group docs       # ok
$ python -m pip install .                  # ok
$ python -m sphinx -T -b html -D language=en docs .../html
build succeeded.
```

## `stable` needs a release — I got this wrong too

I said no release was needed. That is true for `latest` (it builds the default branch, which the README badge points at), but **not** for `stable`, which builds the highest tag — currently `v0.1.8` at commit `4799f714`. That commit predates #207, so it still carries `python: "3.10"` and `requirements: docs/requirements.txt`, and its build fails with the original error:

```
ERROR: Could not open requirements file: docs/requirements.txt
```

No config change can fix that, because RTD checks out the tagged commit. Options once this merges:

1. **Cut a release** — the first tag containing the docs fix makes `stable` build. The *Prepare release* workflow from #208 does this now.
2. **Deactivate `stable`** in RTD Admin → Versions, if you would rather not release just for this.

Worth doing one or the other reasonably soon: the project was auto-disabled once already for excessive build failures, and `stable` will keep failing on every build until its tag moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)