### PR TITLE
Gate publishing on the test matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,23 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  # Wait for the test matrix rather than racing it.  Tests already runs on
+  # every push to main, so keying off that run gates publishing on it without
+  # defining the matrix twice or running it twice per push.
+  workflow_run:
+    workflows: [Tests]
+    types: [completed]
+    branches: [main]
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Publish only when the matrix passed, and only for the run triggered by
+    # the push itself: a manual Tests dispatch should not release anything.
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'push'
     environment:
       name: release
     permissions:
@@ -21,6 +30,9 @@ jobs:
         uses: actions/checkout@v7 # v7.0.1
         with:
           fetch-depth: 2
+          # A workflow_run job defaults to the tip of the default branch, which
+          # may have moved on.  Use the commit that was actually tested.
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0


### PR DESCRIPTION
`Release` and `Tests` both triggered on push to `main`, so they raced — a package could reach PyPI while the matrix that would have caught the problem was still running. There was no gate at all, only the appearance of one.

## Approach

Rather than duplicating a test step inside `release.yml`, key `Release` off the `Tests` run:

```yaml
on:
  workflow_run:
    workflows: [Tests]
    types: [completed]
    branches: [main]

jobs:
  release:
    if: >-
      github.event.workflow_run.conclusion == 'success'
      && github.event.workflow_run.event == 'push'
```

The matrix stays defined in exactly one place, still runs once per push, and `Release` starts only after it finishes green. An inline test step would have meant either duplicating the matrix or gating on a narrower subset of it; a reusable `workflow_call` workflow would have either run the matrix twice per push or hollowed out the `Tests` badge, which reports runs of that workflow on the default branch.

Two details worth flagging:

- **`ref: ${{ github.event.workflow_run.head_sha }}`** on the checkout. A `workflow_run` job checks out the tip of the default branch by default, which may have moved on by the time the matrix finished; this pins it to the commit that was actually tested.
- **`workflow_run.event == 'push'`** so that manually dispatching `Tests` on `main` doesn't kick off a release.

The 3.15 job is `continue-on-error`, so an rc regression reports without blocking a release.

Trusted publishing is unaffected — PyPI matches on repository, workflow filename and environment, all unchanged.

## Verification

Honest limitation: this one can't be proven before merge. `workflow_run` always uses the copy of the workflow on the default branch, so the new trigger cannot fire from a branch and this PR's own CI does not exercise it. I validated the YAML parses to the intended trigger, condition and checkout ref; the real proof is the first push to `main` after this merges, where `Release` should appear only after `Tests` completes.

## Also done

The repo setting that blocked *Prepare release* from opening a PR is now on:

```
before: {"default_workflow_permissions":"write","can_approve_pull_request_reviews":false}
after:  {"default_workflow_permissions":"write","can_approve_pull_request_reviews":true}
```

So the next dispatch should open its PR unaided. That PR won't carry check runs, since PRs created with `GITHUB_TOKEN` don't trigger workflows — which is now harmless, because publishing waits for `Tests` on the merge commit instead.

## Interaction with `release/v0.2.0`

Either merge order works. Merge the release first and the current push-triggered `Release` publishes as it does today; merge this first and the v0.2.0 merge goes through the gate instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)