### PR TITLE
Detect and tag the release without salsify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,18 +37,47 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0
 
-      - name: Check if there is a parent commit
-        id: check-parent-commit
-        run: |
-          echo "sha=$(git rev-parse --verify --quiet HEAD^)" >> "$GITHUB_OUTPUT"
-
-      - name: Detect and tag new version
+      # A release is a commit that changes the version in pyproject.toml.
+      # Read it out of git rather than the working tree so the comparison
+      # needs no second checkout, which is what the action this replaces did
+      # -- it ran `git checkout refs/heads/main`, and there is no local branch
+      # to check out when a workflow_run job pins an explicit commit.
+      - name: Detect a new version
         id: check-version
-        if: steps.check-parent-commit.outputs.sha
-        uses: salsify/action-detect-and-tag-new-version@v2.0.3
-        with:
-          version-command: |
-            uv run --only-dev bump-my-version show current_version
+        run: |
+          current="$(uv run --only-dev bump-my-version show current_version)"
+          echo "current-version=$current" >> "$GITHUB_OUTPUT"
+
+          if ! git rev-parse --verify --quiet HEAD^ > /dev/null; then
+            echo "No parent commit, nothing to compare against."
+            exit 0
+          fi
+
+          # bump-my-version reads the version from a config file, so hand it
+          # the previous commit's pyproject.toml rather than parsing anything
+          # here or checking the parent out over the top of the workspace.
+          git show HEAD^:pyproject.toml > "$RUNNER_TEMP/previous-pyproject.toml"
+          previous="$(uv run --only-dev bump-my-version show current_version \
+            --config-file "$RUNNER_TEMP/previous-pyproject.toml")"
+
+          if [ "$current" = "$previous" ]; then
+            echo "Version unchanged at $current."
+          elif git ls-remote --exit-code --tags origin "refs/tags/v$current" > /dev/null; then
+            echo "Version is $current but v$current is already tagged."
+          else
+            echo "Version changed $previous -> $current."
+            echo "tag=v$current" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag the new version
+        if: steps.check-version.outputs.tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Released version ${{ steps.check-version.outputs.current-version }}"
+          git push origin "$TAG"
+        env:
+          TAG: ${{ steps.check-version.outputs.tag }}
 
       - name: Bump version for developmental release
         if: ${{ ! steps.check-version.outputs.tag }}


### PR DESCRIPTION
`salsify/action-detect-and-tag-new-version` failed on the first `Release` run under the new `workflow_run` trigger ([run 31852474491](https://github.com/dgarnier/inductance/actions/runs/31852474491)):

```
Previous version: 0.1.8
##[error]Command failed with exit code 1: git checkout refs/heads/main
error: pathspec 'refs/heads/main' did not match any file(s) known to git
```

It reads the previous version by checking a branch out over the top of the workspace. A `workflow_run` job pins an explicit commit — that's deliberate, so the tagged commit is the one that was tested — so there is no local `main` ref to check out. The same log also carries `Node 20 is being deprecated`.

## Replacement

`bump-my-version` is already the tool of record for the version, and `show` takes `--config-file`, so it can read the previous commit's `pyproject.toml` straight out of git:

```bash
current="$(uv run --only-dev bump-my-version show current_version)"
git show HEAD^:pyproject.toml > "$RUNNER_TEMP/previous-pyproject.toml"
previous="$(uv run --only-dev bump-my-version show current_version \
  --config-file "$RUNNER_TEMP/previous-pyproject.toml")"
```

Nothing is checked out twice and no version parsing is hand-rolled. Tagging is then `git tag -a` + `git push`. The step keeps the id `check-version` and the `tag` output, so the publish and release-notes steps are untouched.

One behaviour the action didn't have: it now refuses to re-tag a version that already has a tag, so a re-run can't fail on a duplicate.

## Verified

Ran the logic against real commits in this repository:

| commit | versions | result |
|---|---|---|
| `b70c5d5` — #211 merge | 0.1.8 → 0.1.8 | `Version unchanged at 0.1.8.` — no tag, dev release path |
| `4799f71` — real 0.1.7→0.1.8 bump | 0.1.7 → 0.1.8 | `v0.1.8 is already tagged.` — no duplicate tag |
| `f5526fc` — the 0.1.8→0.2.0 bump | 0.1.8 → 0.2.0 | `tag=v0.2.0` |

The middle case is the one the old action would have re-tagged; the last is the golden path, taken from the actual commit the *Prepare release* workflow produced.

Not verifiable before merge: the `workflow_run` plumbing around it, same as #211 — the first push to `main` after this merges is the real test. The gating half already demonstrated it works, since run 31852474491 fired on the tested sha only after `Tests` went green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)